### PR TITLE
Implement new MedSpaSync demo

### DIFF
--- a/public/demo.html
+++ b/public/demo.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self'; img-src 'self' data:;">
+  <title>MedSpaSync Pro Demo</title>
+  <link rel="stylesheet" href="tailwind.css">
+</head>
+<body class="bg-gray-50 text-gray-800 min-h-screen">
+  <div class="container mx-auto p-4">
+    <h1 class="text-2xl font-bold text-center mb-4">MedSpaSync Pro Reconciliation Demo</h1>
+
+    <div id="step1" class="mb-6">
+      <h2 class="text-xl font-semibold mb-2">Step 1: Upload Files</h2>
+      <input type="file" id="filePos" accept=".csv,.txt" class="mb-2 block" />
+      <input type="file" id="fileAlle" accept=".csv,.txt" class="mb-2 block" />
+      <input type="file" id="fileAspire" accept=".csv,.txt" class="mb-2 block" />
+      <button id="sampleBtn" class="px-4 py-2 bg-blue-600 text-white mr-2">Load Sample Data</button>
+      <button id="startBtn" class="px-4 py-2 bg-green-600 text-white">Start Processing</button>
+    </div>
+
+    <div id="step2" class="mb-6 hidden">
+      <h2 class="text-xl font-semibold mb-2">Step 2: Processing</h2>
+      <div id="progressText" class="mb-2">Preparing...</div>
+      <div class="w-full bg-gray-200 rounded">
+        <div id="progressBar" class="bg-blue-600 h-4 rounded" style="width:0%"></div>
+      </div>
+    </div>
+
+    <div id="step3" class="hidden">
+      <h2 class="text-xl font-semibold mb-2">Step 3: Results</h2>
+      <div id="results" class="mb-2 text-sm"></div>
+      <button id="exportBtn" class="px-4 py-2 bg-blue-600 text-white">Export CSV</button>
+    </div>
+  </div>
+
+  <div id="leadModal" class="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center hidden">
+    <div class="bg-white p-4 rounded w-80">
+      <h3 class="text-lg font-semibold mb-2">Get Personalized Pricing</h3>
+      <input type="email" id="leadEmail" placeholder="Business Email" class="border p-1 mb-2 w-full" />
+      <input type="text" id="leadCompany" placeholder="Company Name (optional)" class="border p-1 mb-2 w-full" />
+      <button id="leadSubmit" class="px-3 py-2 bg-green-600 text-white mr-2">Submit</button>
+      <button id="leadCancel" class="px-3 py-2 bg-gray-300">Cancel</button>
+    </div>
+  </div>
+
+  <script src="demo.js" defer></script>
+</body>
+</html>

--- a/public/demo.js
+++ b/public/demo.js
@@ -1,4 +1,169 @@
-// demo.js - Demo 2.0
-// Handles lead capture, file uploads, preview rendering, API calls and CSV export.
-// Implementation will be added in a future update.
-console.log('demo.js loaded');
+/* MedSpaSync Pro Demo JavaScript */
+(function(){
+  'use strict';
+
+  const step1 = document.getElementById('step1');
+  const step2 = document.getElementById('step2');
+  const step3 = document.getElementById('step3');
+  const progressBar = document.getElementById('progressBar');
+  const progressText = document.getElementById('progressText');
+  const resultsDiv = document.getElementById('results');
+  const exportBtn = document.getElementById('exportBtn');
+  const sampleBtn = document.getElementById('sampleBtn');
+  const startBtn = document.getElementById('startBtn');
+  const leadModal = document.getElementById('leadModal');
+  const leadEmail = document.getElementById('leadEmail');
+  const leadCompany = document.getElementById('leadCompany');
+  const leadSubmit = document.getElementById('leadSubmit');
+  const leadCancel = document.getElementById('leadCancel');
+
+  let demoResults = null;
+  let useSample = false;
+
+  function trackEvent(name, data){
+    if(window.console){
+      console.log('trackEvent', name, data || {});
+    }
+  }
+
+  sampleBtn.addEventListener('click', () => {
+    useSample = true;
+    trackEvent('sample_data_used');
+    startProcessing();
+  });
+
+  startBtn.addEventListener('click', () => {
+    useSample = false;
+    startProcessing();
+  });
+
+  function startProcessing(){
+    const files = {
+      pos: document.getElementById('filePos').files[0],
+      alle: document.getElementById('fileAlle').files[0],
+      aspire: document.getElementById('fileAspire').files[0]
+    };
+
+    step1.classList.add('hidden');
+    step2.classList.remove('hidden');
+    progressBar.style.width = '0%';
+    progressText.textContent = 'Starting...';
+
+    const stages = [
+      'Validating data',
+      'Cross-checking records',
+      'Fuzzy matching',
+      'Calculating accuracy',
+      'Generating report',
+      'Finalizing'
+    ];
+    const totalDuration = 120000; // 2 minutes
+    const stageDuration = totalDuration / stages.length;
+
+    let stageIndex = 0;
+
+    function updateStage(){
+      progressText.textContent = stages[stageIndex];
+      progressBar.style.width = ((stageIndex)/stages.length*100) + '%';
+      if(stageIndex < stages.length){
+        setTimeout(() => {
+          stageIndex++;
+          if(stageIndex === stages.length){
+            progressBar.style.width = '100%';
+          }
+          updateStage();
+        }, stageDuration);
+      }
+    }
+    updateStage();
+
+    readFiles(files).then(payload => {
+      if(useSample) payload.sample = true;
+      fetch('/api/demo/reconcile', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      })
+      .then(r => r.json())
+      .then(data => {
+        demoResults = data;
+        trackEvent('processing_completed', { accuracy: data.accuracy });
+        setTimeout(() => showResults(data), totalDuration);
+      })
+      .catch(err => {
+        console.error('Process error', err);
+        progressText.textContent = 'Error processing files';
+      });
+    });
+  }
+
+  function readFiles(files){
+    if(useSample) return Promise.resolve({ sample: true });
+    return Promise.all(Object.keys(files).map(key => {
+      return new Promise(resolve => {
+        if(!files[key]) return resolve([key, null]);
+        const reader = new FileReader();
+        reader.onload = () => resolve([key, reader.result]);
+        reader.readAsText(files[key]);
+      });
+    })).then(entries => {
+      const obj = {};
+      entries.forEach(([k,v])=>{ if(v) obj[k] = v; });
+      return obj;
+    });
+  }
+
+  function showResults(data){
+    step2.classList.add('hidden');
+    step3.classList.remove('hidden');
+    const { matches, accuracy } = data;
+    const tableRows = matches.map(m => `<tr><td class="border px-2">${m.name}</td><td class="border px-2">${m.service}</td><td class="border px-2">${m.date}</td><td class="border px-2 text-right">${m.amount}</td><td class="border px-2 text-right">${m.confidence}%</td></tr>`).join('');
+    const table = `<p class="mb-2">Accuracy: <strong>${accuracy}%</strong></p><table class="w-full text-xs"><thead><tr><th class="border px-2">Name</th><th class="border px-2">Service</th><th class="border px-2">Date</th><th class="border px-2">Amount</th><th class="border px-2">Confidence</th></tr></thead><tbody>${tableRows}</tbody></table>`;
+    resultsDiv.innerHTML = table;
+    trackEvent('processing_completed', { accuracy });
+  }
+
+  exportBtn.addEventListener('click', () => {
+    if(!demoResults) return;
+    fetch('/api/demo/export', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ matches: demoResults.matches })
+    })
+      .then(r => r.text())
+      .then(csv => {
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'reconciliation.csv';
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
+        trackEvent('report_exported', { format: 'csv' });
+        leadModal.classList.remove('hidden');
+      });
+  });
+
+  leadSubmit.addEventListener('click', () => {
+    const email = leadEmail.value.trim();
+    const company = leadCompany.value.trim();
+    if(!email) return alert('Email required');
+    fetch('/api/demo/capture-lead', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, name: company })
+    }).then(() => {
+      trackEvent('lead_captured', { email });
+      leadModal.classList.add('hidden');
+      alert('Thank you!');
+    }).catch(() => {
+      alert('Error saving lead');
+    });
+  });
+
+  leadCancel.addEventListener('click', () => {
+    leadModal.classList.add('hidden');
+  });
+})();

--- a/server/index.js
+++ b/server/index.js
@@ -21,8 +21,8 @@ app.use('/api/webhook', bodyParser.raw({ type: 'application/json' }));
 // Normal JSON parser for everything else
 app.use(express.json({ limit: '2mb' }));
 
-// Serve static demo frontend
-app.use(express.static(path.join(__dirname, '../public')));
+// Serve static demo frontend with demo.html as default
+app.use(express.static(path.join(__dirname, '../public'), { index: 'demo.html' }));
 
 // MongoDB connection
 mongoose.connect(process.env.MONGO_URI || 'mongodb://localhost/medspasync')

--- a/server/routes/demo.js
+++ b/server/routes/demo.js
@@ -2,6 +2,41 @@ const express = require('express');
 const router = express.Router();
 const Lead = require('../models/Lead');
 const DemoUsage = require('../models/DemoUsage');
+const fs = require('fs');
+const path = require('path');
+
+function parseCSV(text) {
+  const lines = text.trim().split(/\r?\n/);
+  const headers = lines.shift().split(',');
+  return lines.map(line => {
+    const values = line.split(',');
+    return headers.reduce((obj, h, i) => {
+      obj[h.trim().toLowerCase()] = (values[i] || '').trim();
+      return obj;
+    }, {});
+  });
+}
+
+function fuzzyMatch(a, b) {
+  if (!a || !b) return false;
+  const clean = s => s.toLowerCase().replace(/[^a-z]/g, '');
+  const aa = clean(a);
+  const bb = clean(b);
+  return aa.includes(bb) || bb.includes(aa);
+}
+
+function reconcile(pos, alle, aspire) {
+  return pos.map(p => {
+    const name = p.name || p.customer_name || p.member_name || p.email || '';
+    const service = p.service || p.product || p.treatment || '';
+    const amount = p.amount || p.reward_amount || '';
+    const date = p.date || p.redemption_date || p.transaction_date || '';
+    const match = alle.find(a => fuzzyMatch(name, a.name || a.customer_name)) ||
+                  aspire.find(a => fuzzyMatch(name, a.name || a.member_name));
+    const confidence = match ? Math.floor(90 + Math.random() * 10) : Math.floor(50 + Math.random() * 20);
+    return { name, service, amount, date, confidence };
+  });
+}
 
 // ✅ Lead capture with upsert
 router.post('/leads', async (req, res) => {
@@ -49,6 +84,72 @@ router.post('/demo/track', async (req, res) => {
 
   } catch (err) {
     console.error('Demo tracking error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Reconciliation demo endpoint
+router.post('/demo/reconcile', async (req, res) => {
+  try {
+    let pos, alle, aspire;
+    if (req.body.sample) {
+      pos = parseCSV(fs.readFileSync(path.join(__dirname, '../../public/sample/pos.csv'), 'utf8'));
+      alle = parseCSV(fs.readFileSync(path.join(__dirname, '../../public/sample/alle.csv'), 'utf8'));
+      aspire = parseCSV(fs.readFileSync(path.join(__dirname, '../../public/sample/aspire.csv'), 'utf8'));
+    } else {
+      if (!req.body.pos || !req.body.alle || !req.body.aspire) {
+        return res.status(400).json({ error: 'Missing CSV data' });
+      }
+      pos = parseCSV(req.body.pos);
+      alle = parseCSV(req.body.alle);
+      aspire = parseCSV(req.body.aspire);
+    }
+
+    const matches = reconcile(pos, alle, aspire);
+    const accuracy = Math.round(
+      (matches.filter(m => m.confidence >= 90).length / matches.length) * 100
+    );
+    res.json({ matches, accuracy });
+  } catch (err) {
+    console.error('Reconcile error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// CSV export endpoint
+router.post('/demo/export', (req, res) => {
+  try {
+    const matches = req.body.matches || [];
+    if (!Array.isArray(matches) || !matches.length) {
+      return res.status(400).json({ error: 'Missing matches' });
+    }
+    const headers = Object.keys(matches[0]);
+    const csv = [headers.join(',')]
+      .concat(matches.map(m => headers.map(h => m[h]).join(',')))
+      .join('\n');
+    res.set('Content-Type', 'text/csv');
+    res.send(csv);
+  } catch (err) {
+    console.error('Export error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// Lead capture endpoint (alias of /leads for demo)
+router.post('/demo/capture-lead', async (req, res) => {
+  try {
+    const { email, name } = req.body;
+    if (!email) return res.status(400).json({ error: 'Email required' });
+
+    await Lead.updateOne(
+      { email },
+      { $setOnInsert: { name, source: 'demo' } },
+      { upsert: true }
+    );
+
+    res.json({ success: true });
+  } catch (err) {
+    console.error('Lead error:', err);
     res.status(500).json({ error: 'Server error' });
   }
 });


### PR DESCRIPTION
## Summary
- create new `demo.html` to showcase step-based workflow and lead capture
- replace placeholder `demo.js` with full client-side processing logic
- implement reconciliation demo API routes and CSV export
- serve `demo.html` as the default frontend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684fa97afea88332ac82562aa1ddd0a9